### PR TITLE
fix 0 returning emptystring

### DIFF
--- a/util/uuid.lua
+++ b/util/uuid.lua
@@ -54,7 +54,7 @@ function INT2HEX(x)
     x = math.floor(x/base)
     s = string.sub(HEXES, d, d)..s
   end
-  if #s == 1 then s = "0" .. s end
+  while #s < 2 do s = "0" .. s end
   return s
 end
 function HEX2INT(s)


### PR DESCRIPTION
Some uuids ended up being too short
Was:

``` lua
INT2HEX(0) == ""
```

Now:

``` lua
INT2HEX(0) == "00"
```
